### PR TITLE
Fix: Align pagination controls styling with overall design

### DIFF
--- a/nfz-notificator/style.css
+++ b/nfz-notificator/style.css
@@ -584,8 +584,6 @@ tbody tr:nth-child(even):hover {
     gap: 1rem;
     margin: 1.5rem 0;
     padding: 1rem;
-    background: #ff0000 !important;
-    border: 5px solid #000000 !important;
     border-radius: 8px;
     position: relative;
     z-index: 9999 !important;
@@ -597,7 +595,7 @@ tbody tr:nth-child(even):hover {
     color: white;
     border: none;
     padding: 0.5rem 1rem;
-    border-radius: 6px;
+    border-radius: 8px;
     cursor: pointer;
     font-size: 0.9rem;
     font-weight: 600;


### PR DESCRIPTION
The .pagination-controls container had a jarring red background and black border, which has been removed. The container will now inherit its background from its parent (the results section), making it visually consistent.

The border-radius of the pagination buttons has been changed from 6px to 8px to match the application's standard button styling. The button colors (blue background, white text) remain, as they align with primary action buttons.

These changes ensure the pagination component is visually harmonious with the rest of the /nfz-notificator application interface.